### PR TITLE
Fix invalid delete operator usage.

### DIFF
--- a/source/source/SimpleCapture.cpp
+++ b/source/source/SimpleCapture.cpp
@@ -183,7 +183,7 @@ SimpleCapture::SimpleCapture(
 	char* charwindowText = new char[(int)(Length + 1)];
 	GetWindowTextA(m_clientHwnd, charwindowText, (Length + 1));
 	m_windowText = charwindowText + std::string(" : ");
-	delete charwindowText;
+	delete[] charwindowText;
 }
 
 //


### PR DESCRIPTION
When allocating with new[] you must use delete[] to release the memory.